### PR TITLE
Support Gatsby v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-split-css",
   "description": "Split css",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "staffe (https://github.com/staffe)",
   "license": "MIT",
   "repository": "https://github.com/staffe/gatsby-plugin-split-css",
@@ -16,7 +16,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "gatsby": "3.x"
+    "gatsby": "3.x || 4.x"
   },
   "scripts": {
     "postversion": "git push && git push --tags"


### PR DESCRIPTION
Currently upgrading to Gatsby v4 shows this warning

```
warn Plugin gatsby-plugin-split-css is not compatible with your gatsby version 4.4.0 - It requires gatsby@3.x
```

This PR modifies gatsby peerDep to support v4

closes #6 